### PR TITLE
discord_message: change start_date

### DIFF
--- a/source-discord-fetcher/source_discord_fetcher/source.py
+++ b/source-discord-fetcher/source_discord_fetcher/source.py
@@ -12,7 +12,7 @@ from airbyte_cdk.sources.streams.http.auth import TokenAuthenticator
 import time
 import os
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 logger = logging.getLogger("airbyte")
 
@@ -153,8 +153,14 @@ class ChannelMessagesStream(DiscordFetcherStream):
     def __init__(self, config: Mapping[str, Any], **kwargs):
         super().__init__(guilds_id=config["guilds_id"], endpoint="/messages", **kwargs)
         self.channel_ids = config["channel_id"]
-        self.start_date = config.get("start_date")
-        
+        # Set default start_date to 4 days before current day if not provided
+        if config.get("start_date"):
+            self.start_date = config["start_date"]
+        else:
+            default_date = datetime.now(timezone.utc) - timedelta(days=4)
+            self.start_date = default_date.strftime("%Y-%m-%d")
+            logger.info("No start_date provided, using default: %s", self.start_date)
+
     @property
     def name(self) -> str:
         return "channel_messages"

--- a/source-discord-fetcher/source_discord_fetcher/spec.yaml
+++ b/source-discord-fetcher/source_discord_fetcher/spec.yaml
@@ -32,7 +32,7 @@ connectionSpecification:
     start_date:
       type: string
       title: Start Date
-      description: "The date from which to start fetching messages. Format YYYY-MM-DD"
+      description: "The date from which to start fetching messages. Format YYYY-MM-DD. Defaults to 4 days before current date if not specified."
       pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
       examples: ["2024-01-01"]
       order: 4


### PR DESCRIPTION
Change start date to automatically set the start date to current date - 4 days.

Because for discord messages the API can only fetch up to 5 days after the start date 