### PR TITLE
app_store: fix type casting

### DIFF
--- a/source-app-store/metadata.yaml
+++ b/source-app-store/metadata.yaml
@@ -14,7 +14,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 464a7cea-0317-485e-9a9c-bcd06155bfff
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.5.0
   dockerRepository: harbor.status.im/bi/airbyte/source-app-store
   githubIssueLabel: source-app-store
   icon: app-store.svg

--- a/source-app-store/source_app_store/source.py
+++ b/source-app-store/source_app_store/source.py
@@ -214,6 +214,34 @@ class AppReportStream(Stream):
             
         return slices
     
+    def _cast_record_types(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Cast record values to match the types declared in the JSON schema.
+        CSV readers return everything as strings, so integer fields need explicit conversion."""
+        if not hasattr(self, "_schema_properties"):
+            self._schema_properties = self.get_json_schema().get("properties", {})
+        properties = self._schema_properties
+
+        for field, value in record.items():
+            if value is None:
+                continue
+            field_schema = properties.get(field)
+            if not field_schema:
+                continue
+            field_type = field_schema.get("type", [])
+            if isinstance(field_type, str):
+                field_type = [field_type]
+            if "integer" in field_type:
+                try:
+                    record[field] = int(value)
+                except (ValueError, TypeError):
+                    record[field] = None
+            elif "number" in field_type:
+                try:
+                    record[field] = float(value)
+                except (ValueError, TypeError):
+                    record[field] = None
+        return record
+
     def read_records(
         self,
         sync_mode: SyncMode,
@@ -258,4 +286,4 @@ class AppReportStream(Stream):
             
             records = read_and_filter_report(file_path, expected_date)
             for record in records:
-                yield record
+                yield self._cast_record_types(record)

--- a/source-app-store/source_app_store/utils.py
+++ b/source-app-store/source_app_store/utils.py
@@ -129,11 +129,6 @@ def download_report_instance(instance_id: str, report_name: str, processing_date
                 if decompress_gzip_to_csv(gz_file_path, csv_file_path):
                     print(f"File downloaded and decompressed successfully to: {csv_file_path}")
                     downloaded_files.add(csv_file_name)
-                    # Clean up the gzipped file
-                    try:
-                        os.remove(gz_file_path)
-                    except Exception as e:
-                        print(f"Warning: Could not remove temporary gzip file: {e}")
                     return csv_file_path
                 else:
                     print(f"Failed to decompress file to CSV")


### PR DESCRIPTION
* Related to https://github.com/status-im/data-docs/issues/166

The bug was : the download counts were appearing as null
The fix: I added type casting to convert CSV string values to integers for fields like Counts, App Apple Identifier...
Other bug: the files .gz were deleted twice

There is a big jump in connector version, because I did not do the update correctly before 