### PR TITLE
github_markdown: new connector to extract markdown from rfp and prize…

### DIFF
--- a/source-github-markdown-fetcher/Dockerfile
+++ b/source-github-markdown-fetcher/Dockerfile
@@ -1,0 +1,8 @@
+FROM --platform=linux/amd64 airbyte/python-connector-base:1.1.0
+
+COPY . ./airbyte/integration_code
+RUN pip install ./airbyte/integration_code
+
+# The entrypoint and default env vars are already set in the base image
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]

--- a/source-github-markdown-fetcher/main.py
+++ b/source-github-markdown-fetcher/main.py
@@ -1,0 +1,4 @@
+from source_github_markdown_fetcher.run import run
+
+if __name__ == "__main__":
+    run()

--- a/source-github-markdown-fetcher/metadata.yaml
+++ b/source-github-markdown-fetcher/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.1.0
   dockerRepository: harbor.status.im/bi/airbyte/source-github-markdown-fetcher
   githubIssueLabel: source-github-markdown-fetcher
   icon: github-markdown-fetcher.svg

--- a/source-github-markdown-fetcher/metadata.yaml
+++ b/source-github-markdown-fetcher/metadata.yaml
@@ -1,0 +1,25 @@
+data:
+  allowedHosts:
+  registries:
+    oss:
+      enabled: false
+    cloud:
+      enabled: false
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:1.0.0@sha256:dd17e347fbda94f7c3abff539be298a65af2d7fc27a307d89297df1081a45c27
+  connectorSubtype: api
+  connectorType: source
+  definitionId: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
+  dockerImageTag: 1.0.0
+  dockerRepository: harbor.status.im/bi/airbyte/source-github-markdown-fetcher
+  githubIssueLabel: source-github-markdown-fetcher
+  icon: github-markdown-fetcher.svg
+  license: MIT
+  name: GitHub Markdown Fetcher
+  releaseDate: TODO
+  supportLevel: community
+  releaseStage: alpha
+  documentationUrl: https://docs.airbyte.com/integrations/sources/github-markdown-fetcher
+  tags:
+    - language:python
+metadataSpecVersion: "1.0"

--- a/source-github-markdown-fetcher/setup.py
+++ b/source-github-markdown-fetcher/setup.py
@@ -1,8 +1,3 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#
-
-
 from setuptools import find_packages, setup
 
 MAIN_REQUIREMENTS = [

--- a/source-github-markdown-fetcher/setup.py
+++ b/source-github-markdown-fetcher/setup.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+
+from setuptools import find_packages, setup
+
+MAIN_REQUIREMENTS = [
+    "airbyte-cdk~=0.2",
+]
+
+TEST_REQUIREMENTS = [
+    "requests-mock~=1.9.3",
+    "pytest~=6.2",
+    "pytest-mock~=3.6.1",
+    "connector-acceptance-test",
+]
+
+setup(
+    name="source_github_markdown_fetcher",
+    description="Source implementation for GitHub Markdown Fetcher (RFPs & Lambda Prizes).",
+    author="Status",
+    author_email="devops@status.im",
+    packages=find_packages(),
+    install_requires=MAIN_REQUIREMENTS,
+    package_data={"": ["*.json", "*.yaml", "schemas/*.json", "schemas/shared/*.json"]},
+    extras_require={
+        "tests": TEST_REQUIREMENTS,
+    },
+    entry_points={
+        "console_scripts": [
+            "source-github-markdown-fetcher=source_github_markdown_fetcher.run:run",
+        ],
+    },
+)

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/__init__.py
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/__init__.py
@@ -1,0 +1,3 @@
+from .source import SourceGithubMarkdownFetcher
+
+__all__ = ["SourceGithubMarkdownFetcher"]

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/run.py
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/run.py
@@ -1,0 +1,8 @@
+import sys
+
+from airbyte_cdk.entrypoint import launch
+from .source import SourceGithubMarkdownFetcher
+
+def run():
+    source = SourceGithubMarkdownFetcher()
+    launch(source, sys.argv[1:])

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/lambda_prizes.json
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/lambda_prizes.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "number": {
+      "type": ["null", "string"]
+    },
+    "title": {
+      "type": ["null", "string"]
+    },
+    "status": {
+      "type": ["null", "string"]
+    },
+    "circle": {
+      "type": ["null", "string"]
+    },
+    "overview": {
+      "type": ["null", "string"]
+    },
+    "effort": {
+      "type": ["null", "string"]
+    },
+    "prize": {
+      "type": ["null", "string"]
+    },
+    "github_url": {
+      "type": ["null", "string"]
+    },
+    "raw_markdown": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/lambda_prizes.json
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/lambda_prizes.json
@@ -28,6 +28,17 @@
     },
     "raw_markdown": {
       "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_modified_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/rfps.json
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/rfps.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "number": {
+      "type": ["null", "string"]
+    },
+    "title": {
+      "type": ["null", "string"]
+    },
+    "category": {
+      "type": ["null", "string"]
+    },
+    "summary": {
+      "type": ["null", "string"]
+    },
+    "github_url": {
+      "type": ["null", "string"]
+    },
+    "status": {
+      "type": ["null", "string"]
+    },
+    "tier": {
+      "type": ["null", "string"]
+    },
+    "raw_markdown": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/rfps.json
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/schemas/rfps.json
@@ -25,6 +25,17 @@
     },
     "raw_markdown": {
       "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_modified_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/source.py
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/source.py
@@ -1,0 +1,222 @@
+import re
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+import requests
+from airbyte_cdk.sources import AbstractSource
+from airbyte_cdk.sources.streams import Stream
+from airbyte_cdk.sources.streams.http import HttpStream
+
+
+class GithubRepoContents(HttpStream):
+    """Base stream that fetches markdown files from a GitHub repo directory and delegates parsing to subclasses."""
+
+    url_base = "https://api.github.com/"
+    primary_key = "number"
+
+    # Subclasses must set these
+    file_prefix: str = ""
+    skip_prefix: str = ""
+
+    def __init__(self, repo: str, path: str, github_token: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.repo = repo
+        self.repo_path = path
+        self.github_token = github_token
+
+    def request_headers(
+        self,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+    ) -> MutableMapping[str, Any]:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.github_token:
+            headers["Authorization"] = f"token {self.github_token}"
+        return headers
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        return None
+
+    def path(self, **kwargs) -> str:
+        return f"repos/{self.repo}/contents/{self.repo_path}"
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        files = response.json()
+        if not isinstance(files, list):
+            return
+
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.github_token:
+            headers["Authorization"] = f"token {self.github_token}"
+
+        md_files = [
+            f for f in files
+            if f["name"].endswith(".md")
+            and f["name"].startswith(self.file_prefix)
+            and not f["name"].startswith(self.skip_prefix)
+        ]
+
+        for f in md_files:
+            raw_resp = requests.get(f["download_url"], headers=headers, timeout=30)
+            raw_resp.raise_for_status()
+            parsed = self.parse_markdown(raw_resp.text, f["name"], f["html_url"])
+            if parsed:
+                yield parsed
+
+    def parse_markdown(self, raw: str, filename: str, html_url: str) -> Optional[dict]:
+        raise NotImplementedError
+
+
+class Rfps(GithubRepoContents):
+    """Stream that fetches RFP markdown files from GitHub and parses them into structured records."""
+
+    file_prefix = "RFP-"
+    skip_prefix = "RFP-000"
+
+    def parse_markdown(self, raw: str, filename: str, html_url: str) -> Optional[dict]:
+        number_m = re.search(r"^(RFP-\d+)", filename)
+        number = number_m.group(1) if number_m else ""
+        if not number or number == "RFP-000":
+            return None
+
+        h1 = re.search(r"^#\s+(.+)", raw, re.MULTILINE)
+        title = re.sub(r"^RFP-\d+[:\s\-\u2014]+", "", h1.group(1)).strip() if h1 else filename
+
+        category_m = (
+            re.search(r"\*\*Category\*\*[:\s]*(.+)", raw, re.IGNORECASE)
+            or re.search(r"Category[:\s|]*([^\n|]+)", raw, re.IGNORECASE)
+        )
+        category = re.sub(r"[`*]", "", category_m.group(1)).strip() if category_m else ""
+
+        status_m = (
+            re.search(r"\*\*Status\*\*[:\s]*(.+)", raw, re.IGNORECASE)
+            or re.search(r"Status[:\s|]*([^\n|]+)", raw, re.IGNORECASE)
+        )
+        status = re.sub(r"[`*]", "", status_m.group(1)).strip() if status_m else "open"
+
+        if "draft" in status.lower():
+            return None
+
+        tier_m = (
+            re.search(r"\*\*Tier\*\*[:\s]*(.+)", raw, re.IGNORECASE)
+            or re.search(r"Tier[:\s|]*([^\n|]+)", raw, re.IGNORECASE)
+        )
+        tier = re.sub(r"[`*]", "", tier_m.group(1)).strip() if tier_m else ""
+
+        summary = ""
+        ov_m = re.search(r"##\s*(?:\U0001f9ed\s*)?Overview\s*\n+([\s\S]*?)(?=\n##)", raw, re.IGNORECASE)
+        if ov_m:
+            lines = [line.strip() for line in ov_m.group(1).split("\n") if line.strip()]
+            summary = " ".join(lines)[:200]
+
+        if not summary:
+            lines = [
+                line.strip()
+                for line in raw.split("\n")
+                if line.strip()
+                and not line.startswith("#")
+                and not line.startswith("|")
+                and not line.startswith("---")
+                and not line.startswith("**")
+            ]
+            summary = " ".join(lines[:3])[:200]
+
+        return {
+            "number": number,
+            "title": title,
+            "category": category,
+            "summary": summary,
+            "github_url": html_url,
+            "status": status,
+            "tier": tier,
+            "raw_markdown": raw,
+        }
+
+
+class LambdaPrizes(GithubRepoContents):
+    """Stream that fetches Lambda Prize markdown files from GitHub and parses them into structured records."""
+
+    file_prefix = "LP-"
+    skip_prefix = "LP-0000"
+
+    def parse_markdown(self, raw: str, filename: str, html_url: str) -> Optional[dict]:
+        number_m = re.search(r"^(LP-\d+)", filename)
+        number = number_m.group(1) if number_m else ""
+        if not number or number == "LP-0000":
+            return None
+
+        h1 = re.search(r"^#\s+LP-\d+:\s*(.+)", raw, re.MULTILINE)
+        title = re.sub(r"\[.*?\]\s*$", "", h1.group(1)).strip() if h1 else filename
+
+        status_line = re.search(r"\*\*`Status[:\s]*([^`]+)`\*\*", raw, re.IGNORECASE)
+        status = status_line.group(1).strip() if status_line else ""
+        if not status:
+            bracket = re.search(r"^#\s+LP-\d+:.*\[([^\]]+)\]", raw, re.MULTILINE)
+            status = bracket.group(1).strip() if bracket else ""
+
+        if "draft" in status.lower():
+            return None
+
+        circle_m = re.search(r"\*\*`Logos Circle[:\s]*([^`]+)`\*\*", raw, re.IGNORECASE)
+        circle = circle_m.group(1).strip() if circle_m else "N/A"
+
+        overview = ""
+        ov_m = re.search(r"##\s*Overview\s*\n+([\s\S]*?)(?=\n##)", raw, re.IGNORECASE)
+        if ov_m:
+            lines = [
+                line.replace(">", "").strip()
+                for line in ov_m.group(1).split("\n")
+                if line.strip() and not line.strip().startswith("TODO")
+            ]
+            overview = " ".join(lines)[:300]
+
+        prize_m = re.search(r"\*\*Total Prize:?\*\*[:\s]*\$?([\w,. ]+)", raw, re.IGNORECASE)
+        prize = prize_m.group(1).strip() if prize_m else "TBD"
+
+        effort_m = re.search(r"\*\*Effort:?\*\*[:\s]*([\w/ ]+)", raw, re.IGNORECASE)
+        effort = effort_m.group(1).strip() if effort_m else ""
+
+        return {
+            "number": number,
+            "title": title,
+            "status": status,
+            "circle": circle,
+            "overview": overview,
+            "effort": effort,
+            "prize": prize,
+            "github_url": html_url,
+            "raw_markdown": raw,
+        }
+
+
+class SourceGithubMarkdownFetcher(AbstractSource):
+    def check_connection(self, logger, config) -> Tuple[bool, any]:
+        try:
+            headers = {"Accept": "application/vnd.github.v3+json"}
+            token = config.get("github_token")
+            if token:
+                headers["Authorization"] = f"token {token}"
+            resp = requests.get(
+                f"https://api.github.com/repos/{config['repo_rfps']}/contents/{config['rfps_path']}",
+                headers=headers,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            return True, None
+        except Exception as e:
+            return False, str(e)
+
+    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+        token = config.get("github_token")
+        return [
+            Rfps(
+                repo=config["repo_rfps"],
+                path=config["rfps_path"],
+                github_token=token,
+            ),
+            LambdaPrizes(
+                repo=config["repo_prizes"],
+                path=config["prizes_path"],
+                github_token=token,
+            ),
+        ]

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/source.py
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/source.py
@@ -13,7 +13,6 @@ class GithubRepoContents(HttpStream):
     url_base = "https://api.github.com/"
     primary_key = "number"
 
-    # Subclasses must set these
     file_prefix: str = ""
     skip_prefix: str = ""
 
@@ -23,16 +22,19 @@ class GithubRepoContents(HttpStream):
         self.repo_path = path
         self.github_token = github_token
 
+    def _auth_headers(self) -> dict:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.github_token:
+            headers["Authorization"] = f"token {self.github_token}"
+        return headers
+
     def request_headers(
         self,
         stream_state: Mapping[str, Any],
         stream_slice: Mapping[str, Any] = None,
         next_page_token: Mapping[str, Any] = None,
     ) -> MutableMapping[str, Any]:
-        headers = {"Accept": "application/vnd.github.v3+json"}
-        if self.github_token:
-            headers["Authorization"] = f"token {self.github_token}"
-        return headers
+        return self._auth_headers()
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         return None
@@ -40,14 +42,25 @@ class GithubRepoContents(HttpStream):
     def path(self, **kwargs) -> str:
         return f"repos/{self.repo}/contents/{self.repo_path}"
 
+    def _get_file_history(self, filename: str) -> Mapping[str, Optional[str]]:
+        url = f"https://api.github.com/repos/{self.repo}/commits"
+        params = {"path": f"{self.repo_path}/{filename}", "per_page": 100}
+        resp = requests.get(url, headers=self._auth_headers(), params=params, timeout=30)
+        if resp.status_code != 200 or not resp.json():
+            return {"created_at": None, "last_modified_at": None, "created_by": None}
+        commits = resp.json()
+        first_commit = commits[-1]
+        author = first_commit.get("author") or {}
+        return {
+            "created_at": first_commit["commit"]["committer"]["date"],
+            "last_modified_at": commits[0]["commit"]["committer"]["date"],
+            "created_by": author.get("login"),
+        }
+
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
         files = response.json()
         if not isinstance(files, list):
             return
-
-        headers = {"Accept": "application/vnd.github.v3+json"}
-        if self.github_token:
-            headers["Authorization"] = f"token {self.github_token}"
 
         md_files = [
             f for f in files
@@ -57,11 +70,47 @@ class GithubRepoContents(HttpStream):
         ]
 
         for f in md_files:
-            raw_resp = requests.get(f["download_url"], headers=headers, timeout=30)
+            raw_resp = requests.get(f["download_url"], headers=self._auth_headers(), timeout=30)
             raw_resp.raise_for_status()
             parsed = self.parse_markdown(raw_resp.text, f["name"], f["html_url"])
             if parsed:
+                parsed.update(self._get_file_history(f["name"]))
                 yield parsed
+
+    def _extract_number(self, filename: str) -> Optional[str]:
+        m = re.search(rf"^({re.escape(self.file_prefix)}\d+)", filename)
+        number = m.group(1) if m else ""
+        if not number or number == self.skip_prefix:
+            return None
+        return number
+
+    def _extract_field(self, raw: str, *patterns: str, default: str = "") -> str:
+        for pat in patterns:
+            m = re.search(pat, raw, re.IGNORECASE)
+            if m:
+                return re.sub(r"[`*]", "", m.group(1)).strip()
+        return default
+
+    def _extract_overview(self, raw: str, max_len: int = 200, strip_chars: str = "") -> str:
+        ov_m = re.search(r"##\s*(?:\U0001f9ed\s*)?Overview\s*\n+([\s\S]*?)(?=\n##)", raw, re.IGNORECASE)
+        if ov_m:
+            lines = []
+            for line in ov_m.group(1).split("\n"):
+                cleaned = line.strip()
+                if not cleaned or cleaned.startswith("TODO"):
+                    continue
+                for ch in strip_chars:
+                    cleaned = cleaned.replace(ch, "")
+                lines.append(cleaned.strip())
+            if lines:
+                return " ".join(lines)[:max_len]
+
+        lines = [
+            line.strip() for line in raw.split("\n")
+            if line.strip()
+            and not line.startswith(("#", "|", "---", "**"))
+        ]
+        return " ".join(lines[:3])[:max_len]
 
     def parse_markdown(self, raw: str, filename: str, html_url: str) -> Optional[dict]:
         raise NotImplementedError
@@ -74,61 +123,30 @@ class Rfps(GithubRepoContents):
     skip_prefix = "RFP-000"
 
     def parse_markdown(self, raw: str, filename: str, html_url: str) -> Optional[dict]:
-        number_m = re.search(r"^(RFP-\d+)", filename)
-        number = number_m.group(1) if number_m else ""
-        if not number or number == "RFP-000":
+        number = self._extract_number(filename)
+        if not number:
             return None
 
         h1 = re.search(r"^#\s+(.+)", raw, re.MULTILINE)
         title = re.sub(r"^RFP-\d+[:\s\-\u2014]+", "", h1.group(1)).strip() if h1 else filename
 
-        category_m = (
-            re.search(r"\*\*Category\*\*[:\s]*(.+)", raw, re.IGNORECASE)
-            or re.search(r"Category[:\s|]*([^\n|]+)", raw, re.IGNORECASE)
+        status = self._extract_field(
+            raw,
+            r"\*\*Status\*\*[:\s]*(.+)",
+            r"Status[:\s|]*([^\n|]+)",
+            default="open",
         )
-        category = re.sub(r"[`*]", "", category_m.group(1)).strip() if category_m else ""
-
-        status_m = (
-            re.search(r"\*\*Status\*\*[:\s]*(.+)", raw, re.IGNORECASE)
-            or re.search(r"Status[:\s|]*([^\n|]+)", raw, re.IGNORECASE)
-        )
-        status = re.sub(r"[`*]", "", status_m.group(1)).strip() if status_m else "open"
-
         if "draft" in status.lower():
             return None
-
-        tier_m = (
-            re.search(r"\*\*Tier\*\*[:\s]*(.+)", raw, re.IGNORECASE)
-            or re.search(r"Tier[:\s|]*([^\n|]+)", raw, re.IGNORECASE)
-        )
-        tier = re.sub(r"[`*]", "", tier_m.group(1)).strip() if tier_m else ""
-
-        summary = ""
-        ov_m = re.search(r"##\s*(?:\U0001f9ed\s*)?Overview\s*\n+([\s\S]*?)(?=\n##)", raw, re.IGNORECASE)
-        if ov_m:
-            lines = [line.strip() for line in ov_m.group(1).split("\n") if line.strip()]
-            summary = " ".join(lines)[:200]
-
-        if not summary:
-            lines = [
-                line.strip()
-                for line in raw.split("\n")
-                if line.strip()
-                and not line.startswith("#")
-                and not line.startswith("|")
-                and not line.startswith("---")
-                and not line.startswith("**")
-            ]
-            summary = " ".join(lines[:3])[:200]
 
         return {
             "number": number,
             "title": title,
-            "category": category,
-            "summary": summary,
-            "github_url": html_url,
             "status": status,
-            "tier": tier,
+            "category": self._extract_field(raw, r"\*\*Category\*\*[:\s]*(.+)", r"Category[:\s|]*([^\n|]+)"),
+            "tier": self._extract_field(raw, r"\*\*Tier\*\*[:\s]*(.+)", r"Tier[:\s|]*([^\n|]+)"),
+            "summary": self._extract_overview(raw, max_len=200),
+            "github_url": html_url,
             "raw_markdown": raw,
         }
 
@@ -140,50 +158,29 @@ class LambdaPrizes(GithubRepoContents):
     skip_prefix = "LP-0000"
 
     def parse_markdown(self, raw: str, filename: str, html_url: str) -> Optional[dict]:
-        number_m = re.search(r"^(LP-\d+)", filename)
-        number = number_m.group(1) if number_m else ""
-        if not number or number == "LP-0000":
+        number = self._extract_number(filename)
+        if not number:
             return None
 
         h1 = re.search(r"^#\s+LP-\d+:\s*(.+)", raw, re.MULTILINE)
         title = re.sub(r"\[.*?\]\s*$", "", h1.group(1)).strip() if h1 else filename
 
-        status_line = re.search(r"\*\*`Status[:\s]*([^`]+)`\*\*", raw, re.IGNORECASE)
-        status = status_line.group(1).strip() if status_line else ""
-        if not status:
-            bracket = re.search(r"^#\s+LP-\d+:.*\[([^\]]+)\]", raw, re.MULTILINE)
-            status = bracket.group(1).strip() if bracket else ""
-
+        status = self._extract_field(
+            raw,
+            r"\*\*`Status[:\s]*([^`]+)`\*\*",
+            r"^#\s+LP-\d+:.*\[([^\]]+)\]",
+        )
         if "draft" in status.lower():
             return None
-
-        circle_m = re.search(r"\*\*`Logos Circle[:\s]*([^`]+)`\*\*", raw, re.IGNORECASE)
-        circle = circle_m.group(1).strip() if circle_m else "N/A"
-
-        overview = ""
-        ov_m = re.search(r"##\s*Overview\s*\n+([\s\S]*?)(?=\n##)", raw, re.IGNORECASE)
-        if ov_m:
-            lines = [
-                line.replace(">", "").strip()
-                for line in ov_m.group(1).split("\n")
-                if line.strip() and not line.strip().startswith("TODO")
-            ]
-            overview = " ".join(lines)[:300]
-
-        prize_m = re.search(r"\*\*Total Prize:?\*\*[:\s]*\$?([\w,. ]+)", raw, re.IGNORECASE)
-        prize = prize_m.group(1).strip() if prize_m else "TBD"
-
-        effort_m = re.search(r"\*\*Effort:?\*\*[:\s]*([\w/ ]+)", raw, re.IGNORECASE)
-        effort = effort_m.group(1).strip() if effort_m else ""
 
         return {
             "number": number,
             "title": title,
             "status": status,
-            "circle": circle,
-            "overview": overview,
-            "effort": effort,
-            "prize": prize,
+            "circle": self._extract_field(raw, r"\*\*`Logos Circle[:\s]*([^`]+)`\*\*", default="N/A"),
+            "overview": self._extract_overview(raw, max_len=300, strip_chars=">"),
+            "effort": self._extract_field(raw, r"\*\*Effort:?\*\*[:\s]*([\w/ ]+)"),
+            "prize": self._extract_field(raw, r"\*\*Total Prize:?\*\*[:\s]*\$?([\w,. ]+)", default="TBD"),
             "github_url": html_url,
             "raw_markdown": raw,
         }

--- a/source-github-markdown-fetcher/source_github_markdown_fetcher/spec.yaml
+++ b/source-github-markdown-fetcher/source_github_markdown_fetcher/spec.yaml
@@ -1,0 +1,29 @@
+documentationUrl: https://docsurl.com
+connectionSpecification:
+  $schema: http://json-schema.org/draft-07/schema#
+  title: GitHub Markdown Fetcher Source Spec
+  type: object
+  required:
+    - repo_rfps
+    - rfps_path
+    - repo_prizes
+    - prizes_path
+  properties:
+    repo_rfps:
+      type: string
+      description: "GitHub repository for RFPs in owner/repo format (e.g. logos-co/rfp)"
+    rfps_path:
+      type: string
+      description: "Path to the RFPs directory in the repository"
+      default: "RFPs"
+    repo_prizes:
+      type: string
+      description: "GitHub repository for Lambda Prizes in owner/repo format (e.g. logos-co/lambda-prize)"
+    prizes_path:
+      type: string
+      description: "Path to the prizes directory in the repository"
+      default: "prizes"
+    github_token:
+      type: string
+      description: "GitHub personal access token (optional, raises rate limit)"
+      airbyte_secret: true


### PR DESCRIPTION
* Linked to https://github.com/status-im/data-docs/issues/172

New custom Airbyte source connector that fetches and parses markdown files from GitHub repositories, extracting structured data from RFPs (logos-co/rfp) and Lambda Prizes (logos-co/lambda-prize)

2 streams:
- rfps: extracts number, title, category, status, tier, summary, and raw markdown
- lambda_prizes:  extracts number, title, status, circle, overview, effort, prize amount, and raw markdown

related [airbyte connector](https://airbyte.bi.status.im/workspaces/f722c4e1-6c83-4568-8f3b-f51e47827404/connections/b6c4969c-68f4-4bc3-9555-d040ed22ba2b/replication)