### PR TITLE
gh_search: adding a stream to fetch individual items in search results

### DIFF
--- a/source-github-search-count/metadata.yaml
+++ b/source-github-search-count/metadata.yaml
@@ -14,7 +14,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.1.0
   dockerRepository: harbor.status.im/bi/airbyte/source-github-search-count
   githubIssueLabel: source-github-search-count
   license: MIT

--- a/source-github-search-count/source_github_search_count/schemas/search_items.json
+++ b/source-github-search-count/source_github_search_count/schemas/search_items.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "query_name": {
+      "type": ["null", "string"]
+    },
+    "query": {
+      "type": ["null", "string"]
+    },
+    "name": {
+      "type": ["null", "string"]
+    },
+    "path": {
+      "type": ["null", "string"]
+    },
+    "html_url": {
+      "type": ["null", "string"]
+    },
+    "score": {
+      "type": ["null", "number"]
+    },
+    "repository_id": {
+      "type": ["null", "integer"]
+    },
+    "repository_name": {
+      "type": ["null", "string"]
+    },
+    "repository_full_name": {
+      "type": ["null", "string"]
+    },
+    "repository_owner_login": {
+      "type": ["null", "string"]
+    },
+    "repository_owner_id": {
+      "type": ["null", "integer"]
+    },
+    "repository_owner_type": {
+      "type": ["null", "string"]
+    },
+    "repository_private": {
+      "type": ["null", "boolean"]
+    },
+    "repository_fork": {
+      "type": ["null", "boolean"]
+    },
+    "repository_html_url": {
+      "type": ["null", "string"]
+    },
+    "repository_description": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/source-github-search-count/source_github_search_count/source.py
+++ b/source-github-search-count/source_github_search_count/source.py
@@ -14,6 +14,10 @@ logger = logging.getLogger("airbyte")
 SCHEMAS_DIR = os.path.join(os.path.dirname(__file__), "schemas")
 GITHUB_SEARCH_URL = "https://api.github.com/search/code"
 
+REQUEST_SLEEP_SECONDS = 6
+MAX_RESULTS_PER_QUERY = 1000
+PER_PAGE = 100
+
 
 def _load_schema(name: str) -> dict:
     with open(os.path.join(SCHEMAS_DIR, f"{name}.json"), "r") as f:
@@ -27,7 +31,19 @@ def _github_headers(token: str) -> dict:
     }
 
 
+def _search_page(token: str, query: str, page: int, per_page: int) -> dict:
+    resp = requests.get(
+        GITHUB_SEARCH_URL,
+        params={"q": query, "page": page, "per_page": per_page},
+        headers=_github_headers(token),
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 class SearchCountsStream(Stream):
+    """One row per query with aggregate total_count."""
+
     primary_key = None
     name = "search_counts"
 
@@ -44,18 +60,12 @@ class SearchCountsStream(Stream):
         stream_slice: Optional[Mapping[str, Any]] = None,
         stream_state: Optional[Mapping[str, Any]] = None,
     ) -> Iterable[Mapping[str, Any]]:
-        headers = _github_headers(self._config["github_token"])
+        token = self._config["github_token"]
         queries = self._config["search_queries"]
 
         for i, sq in enumerate(queries):
-            logger.info(f"Searching GitHub for query '{sq['name']}': {sq['query']}")
-            resp = requests.get(
-                GITHUB_SEARCH_URL,
-                params={"q": sq["query"]},
-                headers=headers,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            logger.info(f"Searching GitHub (count) for '{sq['name']}': {sq['query']}")
+            data = _search_page(token, sq["query"], page=1, per_page=1)
 
             yield {
                 "query_name": sq["name"],
@@ -65,7 +75,80 @@ class SearchCountsStream(Stream):
             }
 
             if i < len(queries) - 1:
-                time.sleep(6)
+                time.sleep(REQUEST_SLEEP_SECONDS)
+
+
+class SearchItemsStream(Stream):
+    """One row per search result item, with repo/owner metadata flattened."""
+
+    primary_key = None
+    name = "search_items"
+
+    def __init__(self, config: Mapping[str, Any]):
+        self._config = config
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return _load_schema(self.name)
+
+    @staticmethod
+    def _flatten_item(query_name: str, query: str, item: Mapping[str, Any]) -> Mapping[str, Any]:
+        repo = item.get("repository") or {}
+        owner = repo.get("owner") or {}
+        return {
+            "query_name": query_name,
+            "query": query,
+            "name": item.get("name"),
+            "path": item.get("path"),
+            "html_url": item.get("html_url"),
+            "score": item.get("score"),
+            "repository_id": repo.get("id"),
+            "repository_name": repo.get("name"),
+            "repository_full_name": repo.get("full_name"),
+            "repository_owner_login": owner.get("login"),
+            "repository_owner_id": owner.get("id"),
+            "repository_owner_type": owner.get("type"),
+            "repository_private": repo.get("private"),
+            "repository_fork": repo.get("fork"),
+            "repository_html_url": repo.get("html_url"),
+            "repository_description": repo.get("description"),
+        }
+
+    def read_records(
+        self,
+        sync_mode: SyncMode,
+        cursor_field: Optional[List[str]] = None,
+        stream_slice: Optional[Mapping[str, Any]] = None,
+        stream_state: Optional[Mapping[str, Any]] = None,
+    ) -> Iterable[Mapping[str, Any]]:
+        token = self._config["github_token"]
+        queries = self._config["search_queries"]
+
+        first_request = True
+        for sq in queries:
+            query_name = sq["name"]
+            query = sq["query"]
+            logger.info(f"Searching GitHub (items) for '{query_name}': {query}")
+
+            fetched = 0
+            page = 1
+            while fetched < MAX_RESULTS_PER_QUERY:
+                if not first_request:
+                    time.sleep(REQUEST_SLEEP_SECONDS)
+                first_request = False
+
+                data = _search_page(token, query, page=page, per_page=PER_PAGE)
+                items = data.get("items") or []
+                if not items:
+                    break
+
+                for item in items:
+                    yield self._flatten_item(query_name, query, item)
+
+                fetched += len(items)
+                total = data.get("total_count", 0)
+                if fetched >= total or len(items) < PER_PAGE:
+                    break
+                page += 1
 
 
 class SourceGithubSearchCount(AbstractSource):
@@ -83,4 +166,7 @@ class SourceGithubSearchCount(AbstractSource):
             return False, str(e)
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
-        return [SearchCountsStream(config)]
+        return [
+            SearchCountsStream(config),
+            SearchItemsStream(config),
+        ]


### PR DESCRIPTION
* Linked to https://github.com/status-im/data-docs/issues/187

Improving the connector to fetch individual items in github search results instead of just the total count of results.
This way we can filter out results that appear in our repos.

We keep the `SearchCountsStream` here because it's only one API call, it's also the only way to get the exact amount of results if we have more than 1000 results per query. Also if this airbyte connector is consuming too many API calls we can only keep this stream alive.