### PR TITLE
Bamboohr: add twitter handle

### DIFF
--- a/source-custom-bamboo-hr/metadata.yaml
+++ b/source-custom-bamboo-hr/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: a02261a4-413f-46a3-990b-f9260dfda049
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: harbor.status.im/bi/airbyte/source-custom-bamboo-hr
   githubIssueLabel: source-custom-bamboo-hr
   icon: custom-bamboo-hr.svg

--- a/source-custom-bamboo-hr/source_custom_bamboo_hr/schemas/employees_details.json
+++ b/source-custom-bamboo-hr/source_custom_bamboo_hr/schemas/employees_details.json
@@ -38,6 +38,9 @@
     "customDiscordUsername": {
       "type": ["null", "string"]
     },
+    "twitterFeed": {
+      "type": ["null", "string"]
+    },
     "supervisor": {
       "type": ["null", "string"]
     },

--- a/source-custom-bamboo-hr/source_custom_bamboo_hr/source.py
+++ b/source-custom-bamboo-hr/source_custom_bamboo_hr/source.py
@@ -15,7 +15,7 @@ from airbyte_cdk.sources.streams.http.auth import BasicHttpAuthenticator
 
 logger = logging.getLogger("airbyte")
 
-FIELDS_PARAMS = "id,firstName,lastName,displayedName,division,team,department,customENSUsername,customStatusPublicKey,customGitHubusername,customDiscordUsername,supervisor,hireDate,bestEmail,city,country,jobTitle"
+FIELDS_PARAMS = "id,firstName,lastName,displayedName,division,team,department,customENSUsername,customStatusPublicKey,customGitHubusername,customDiscordUsername,twitterFeed,supervisor,hireDate,bestEmail,city,country,jobTitle"
 
 class CustomBambooHrStream(HttpStream, ABC):
     url_base = "https://api.bamboohr.com/api/gateway.php/"


### PR DESCRIPTION
Adding twitter handle to the bamboo hr extraction.

NB: The source `Custom BambooHR` can be deleted in Airbyte since we use `source-custom-bamboo-hr`